### PR TITLE
Upgrade to Go 1.18 for GHA jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.18
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [1.15.x]
+        go: [1.18.x]
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
Should have been done when upgrading to Go 1.18 in https://github.com/drlau/akashi/pull/12.